### PR TITLE
feat: ensure commit messages conform to conventional commits

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,6 +17,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
+      - name: Commit Lint 
+        run: | 
+          gitlint --commits origin/master..
       - name: Format
         run: |
           black . --check --diff

--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,13 @@
+# Configuration file for gitlint, used via pre-commit
+# http://jorisroovers.github.io/gitlint/configuration/
+
+[general]
+# Ignore certain rules, you can reference them by their id or by their full name
+ignore=body-is-missing
+
+# Enable community contributed rule for conventional commits
+contrib=contrib-title-conventional-commits
+
+[contrib-title-conventional-commits]
+# Specify allowed commit types. For details see: https://www.conventionalcommits.org/
+types = build, ci, docs, feat, fix, perf, refactor, style, test

--- a/.gitlint
+++ b/.gitlint
@@ -1,5 +1,6 @@
 # Configuration file for gitlint, used via pre-commit
-# http://jorisroovers.github.io/gitlint/configuration/
+# Configuration docs: http://jorisroovers.github.io/gitlint/configuration/
+# Default rules: https://github.com/jorisroovers/gitlint/blob/master/docs/rules.md
 
 [general]
 # Ignore certain rules, you can reference them by their id or by their full name
@@ -7,6 +8,13 @@ ignore=body-is-missing
 
 # Enable community contributed rule for conventional commits
 contrib=contrib-title-conventional-commits
+
+[title-max-length]
+line-length=72
+
+# [title-match-regex]
+# Uncomment to ensure that there is an issue referenced in every commit title
+# regex=^.*?#[0-9]+\b.*?$
 
 [contrib-title-conventional-commits]
 # Specify allowed commit types. For details see: https://www.conventionalcommits.org/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+# Configuration file for pre-commit (https://pre-commit.com/)
+
+repos:
+-  repo: https://github.com/jorisroovers/gitlint
+   rev: v0.12.0
+   hooks:
+   -  id: gitlint
+      stages: [commit-msg]
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,11 @@ jobs:
     install:
       - python -m pip install --upgrade pip
       - pip install -r requirements-dev.txt
+    before_script:
+      # Travis-CI does not include master in the build by default
+      - git fetch origin refs/heads/master:refs/heads/master
     script:
+      - gitlint --commits master..
       - black . --check --diff
       - isort -rc . --check --diff
       - pylint salutation.py test_salutation.py

--- a/README.md
+++ b/README.md
@@ -51,6 +51,22 @@ Line length needs to be consistently configured for formatting, linting and whil
 * `.pylintrc`
 * `pyproject.toml`
 
+## Commit Messages
+
+Commit messages must conform to [conventional commits](https://www.conventionalcommits.org/):
+
+```
+type(optional-scope): description
+```
+
+where type is one of `build`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `style`, `test` as specified in `.gitlint`.
+
+For example:
+
+```
+ci(github-actions): add new matrix jobs for Python 3.8
+```
+
 ## Continuous Integration
 
 ### GitHub Actions
@@ -118,8 +134,15 @@ source .venv/bin/activate
 
 `python3` must be 3.6+
 
-Install the required dependencies.
+Upgrade pip and install the required dependencies.
 
 ```bash
+pip install --upgrade pip
 pip install -r requirements-dev.txt
+```
+
+Install commit-msg git hook.
+
+```bash
+pre-commit install --hook-type commit-msg
 ```

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,6 @@
 black==19.3b0
+gitlint==0.12.0
 isort==4.3.21
+pre-commit==1.18.3
 pylint==2.4.3
 pytest==5.2.1


### PR DESCRIPTION
Closes #3

* adds commit linting via [pre-commit](https://pre-commit.com/) and [gitlint](http://jorisroovers.com/gitlint/)
* `commit-msg` hook will check commit messages before they are commited locally
* continuous integration checks via GitHub Actions and Travis-CI will both check that all commits since `master` conform, not just the current commit (this prevents a non-conforming commit from being merged in an environment where the hooks are not installed)