### PR TITLE
fix: allow TODO in comments

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -4,3 +4,5 @@ disable =
         invalid-name
 [FORMAT]
 max-line-length=127
+[MISCELLANEOUS]
+notes=FIXME,XXX


### PR DESCRIPTION
This allows TODO: to be present in comments, it is useful to explain to future developers areas of concern inside of a codebase.