### PR TITLE
Add more commit types (chore and revert)

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -18,4 +18,4 @@ line-length=72
 
 [contrib-title-conventional-commits]
 # Specify allowed commit types. For details see: https://www.conventionalcommits.org/
-types = build, ci, docs, feat, fix, perf, refactor, style, test
+types = build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Commit messages must conform to [conventional commits](https://www.conventionalc
 type(optional-scope): description
 ```
 
-where type is one of `build`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `style`, `test` as specified in `.gitlint`.
+where type is one of `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test` as specified in `.gitlint`.
 
 For example:
 


### PR DESCRIPTION
Adding more commit types:
* chore: e.g. adding a new file to `.gitignore`
* revert: for commits that only revert a previous commit