### PR TITLE
Allow any line length for the optional body of commit messages

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -4,7 +4,7 @@
 
 [general]
 # Ignore certain rules, you can reference them by their id or by their full name
-ignore=body-is-missing
+ignore=body-is-missing, body-max-line-length
 
 # Enable community contributed rule for conventional commits
 contrib=contrib-title-conventional-commits


### PR DESCRIPTION
Fixes #12 

Rationale:
a) dependabot doesn't work with a maximum line length in the body
b) commitlint defaults to infinite line length in the body
c) most editors / terminals will wrap just fine anyway