### PR TITLE
ci: simplify CI steps and target Python 3.8 only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  linter:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 name: Build
+
 on:
   push:
     branches:
@@ -8,15 +9,12 @@ on:
 jobs:
   linter:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python: ["3.6", "3.7"]
     steps:
       - uses: actions/checkout@v1
-      - name: Use Python ${{ matrix.python }}
+      - name: Setup Python 3.8
         uses: actions/setup-python@v2.1.2
         with:
-          python-version: ${{ matrix.python }}
+          python-version: 3.8
       - name: Install
         run: |
           python -m pip install --upgrade pip
@@ -38,23 +36,6 @@ jobs:
       - name: Import Sorting
         run: |
           isort -rc . --check --diff
-
-  test:
-    runs-on: ubuntu-latest
-    needs: linter
-    strategy:
-      matrix:
-        python: ["3.6", "3.7"]
-    steps:
-      - uses: actions/checkout@v1
-      - name: Use Python ${{ matrix.python }}
-        uses: actions/setup-python@v2.1.2
-        with:
-          python-version: ${{ matrix.python }}
-      - name: Install
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
       - name: Test
         run: |
           pytest


### PR DESCRIPTION
Closes #57

Deduplicate CI steps by combining "linter" and "test" jobs.
Target Python 3.8 for new Python projects.