### PR TITLE
ci: remove recursive flag for isort

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           pylint salutation.py test_salutation.py
       - name: Import Sorting
         run: |
-          isort -rc . --check --diff
+          isort . --check --diff
       - name: Test
         run: |
           pytest

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ This command runs the `pylint` checks for errors, bugs, non-conforming code styl
 `pylint` uses the configurations stored in `.pylintrc`.
 
 ```bash
-isort -rc . --check --diff
+isort . --check --diff
 ```
 
 This command runs the `isort` import sorter recursively over the Python files in the current directory. The `--check` flag ensures that the command will error out if any changes are required, rather than making changes. `--diff` will show the difference.


### PR DESCRIPTION
As of `isort 5.0.0`, the `-rc` flag (recursive) is deprecated / redundant as this behaviour is now provided by default.