### PR TITLE
feat: Run all pre-commit hooks in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,13 +32,7 @@ jobs:
           poetry run gitlint --commits "origin/${{ github.base_ref }}...HEAD"
       - name: Format
         run: |
-          poetry run black . --check --diff
-      - name: Lint
-        run: |
-          poetry run pylint salutation.py test_salutation.py
-      - name: Import Sorting
-        run: |
-          poetry run isort -rc . --check --diff
+          poetry run pre-commit run --all-files
       - name: Test
         run: |
           poetry run pytest


### PR DESCRIPTION
Rather than running a specific subset of linters, this keeps the results
in CI in sync with the results when committing.