### PR TITLE
feat: Format files using Prettier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,41 +2,46 @@
 # Please run `pre-commit run --all-files` when adding or changing entries.
 
 repos:
-    - repo: local
-      hooks:
-          - id: black
-            name: black
-            entry: black
-            language: system
-            stages: [commit]
-            types: [python]
+  - repo: local
+    hooks:
+      - id: black
+        name: black
+        entry: black
+        language: system
+        stages: [commit]
+        types: [python]
 
-          - id: gitlint
-            name: gitlint
-            entry: gitlint
-            args: [--msg-filename]
-            language: system
-            stages: [commit-msg]
+      - id: gitlint
+        name: gitlint
+        entry: gitlint
+        args: [--msg-filename]
+        language: system
+        stages: [commit-msg]
 
-          - id: isort
-            name: isort
-            entry: isort
-            language: system
-            stages: [commit]
-            types: [python]
+      - id: isort
+        name: isort
+        entry: isort
+        language: system
+        stages: [commit]
+        types: [python]
 
-          - id: mypy
-            name: mypy
-            entry: mypy
-            args: [--no-incremental]
-            language: system
-            stages: [commit]
-            types: [python]
-            require_serial: true
+      - id: mypy
+        name: mypy
+        entry: mypy
+        args: [--no-incremental]
+        language: system
+        stages: [commit]
+        types: [python]
+        require_serial: true
 
-          - id: pylint
-            name: pylint
-            entry: pylint
-            language: system
-            stages: [commit]
-            types: [python]
+      - id: pylint
+        name: pylint
+        entry: pylint
+        language: system
+        stages: [commit]
+        types: [python]
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: a99a3fbe79a9d346cabd02a5e167ad0edafe616b # v2.3.0
+    hooks:
+      - id: prettier

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![License](https://badgen.net/github/license/linz/template-python-hello-world?labelColor=2e3a44&label=License)](https://github.com/linz/template-python-hello-world/blob/master/LICENSE)
 [![Conventional Commits](https://badgen.net/badge/Commits/conventional?labelColor=2e3a44&color=EC5772)](https://conventionalcommits.org)
 [![Code Style](https://badgen.net/badge/Code%20Style/black?labelColor=2e3a44&color=000000)](https://github.com/psf/black)
+[![Code Style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 
 ## Why?
 


### PR DESCRIPTION
As far as I can tell there is no Python package for this, so I've used
the solution recommended by the official Prettier documentation
<https://prettier.io/docs/en/precommit.html#option-3-pre-commithttpsgithubcompre-commitpre-commit>.

I've specified a commit ID rather than a tag for security reasons - if
anyone manages to replace the tag with some malicious code we won't be
affected.

Closes https://github.com/linz/template-python-hello-world/issues/114