### PR TITLE
fix: Run prettier only on commit stage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,3 +45,4 @@ repos:
     rev: a99a3fbe79a9d346cabd02a5e167ad0edafe616b # v2.3.0
     hooks:
       - id: prettier
+        stages: [commit]


### PR DESCRIPTION
Otherwise it tries to lint `.git/COMMIT_EDITMSG`.