### PR TITLE
chore: Use more default pylint settings

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -4,5 +4,3 @@ disable =
         invalid-name
 [FORMAT]
 max-line-length=127
-[MISCELLANEOUS]
-notes=FIXME,XXX

--- a/.pylintrc
+++ b/.pylintrc
@@ -2,5 +2,3 @@
 disable =
         bad-continuation,
         invalid-name
-[FORMAT]
-max-line-length=127


### PR DESCRIPTION
This might be controversial, but a max line length of 127 seems excessive. 100 is already big enough that it's hard to have two readable files side by side.