### PR TITLE
feat: Exclude rather than include code for coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,8 @@ fail_under = 100
 
 [tool.coverage.run]
 branch = true
-source = [
-    "module_name",
-    "tests",
+omit = [
+    ".venv/*",
 ]
 
 [tool.isort]


### PR DESCRIPTION
Avoids two issues:

- Having to change the include when renaming or adding a top-level
  directory
- Not detecting the correct coverage when forgetting to update the
  include list