### PR TITLE
chore: Remove Python 3.10 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,17 +8,11 @@ on:
 
 jobs:
   build:
-    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04]
         python: [3.6, 3.7, 3.8, 3.9]
-        experimental: [false]
-        include:
-          - os: ubuntu-latest
-            python: "3.10.0-rc.1"
-            experimental: true
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2.3.4


### PR DESCRIPTION
Even though the build is not needed to merge, the GitHub UI still shows
it as a failure. This is misleading for reviewers. Unfortunately GitHub
Actions does not yet have any way to indicate that an error in a
specific job should not be considered as failing the pipeline
<https://github.com/actions/toolkit/issues/399>.