### PR TITLE
feat: Create single summary test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,14 @@ jobs:
           name: code-coverage-report
           path: htmlcov
         if: ${{ failure() }}
+
+  finalise:
+    if: always()
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
GitHub branch protection rules do not have a feature for specifying that
*all* workflow jobs must pass before the branch can be merged. Instead
we have to specify the job names explicitly. Since each job in a matrix
gets a different name, that means whenever the matrix is updated the
branch protection rule must be updated. To work around this we use a
non-matrix "finalise" job which checks that all dependent jobs passed.

Post-merge task:

- [ ] Set "finalise" as the only required job for merging.