### PR TITLE
refactor: Simplify Python package install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,11 @@ jobs:
           key: ${{ matrix.os }}-pip-${{ secrets.CACHE_SEED }}-${{ matrix.python }}-${{ hashFiles('./poetry.lock') }}
           restore-keys: ${{ matrix.os }}-pip-${{ secrets.CACHE_SEED }}-${{ matrix.python }}-
       - name: Upgrade pip
-        run: python -m pip install --upgrade pip
+        run: pip install --upgrade pip
       - name: Install Poetry
-        run: python -m pip install poetry
+        run: pip install poetry
       - name: Install Python dependencies
-        run: python -m poetry install
+        run: poetry install
       - name: Lint Last Commit
         if: github.event_name == 'push'
         run: poetry run gitlint

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -16,11 +16,12 @@ jobs:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ secrets.CACHE_SEED }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('./poetry.lock') }}
           restore-keys: ${{ runner.os }}-pip-${{ secrets.CACHE_SEED }}-${{ env.PYTHON_VERSION }}-
-      - name: Install
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install poetry
-          python -m poetry install
+      - name: Upgrade pip
+        run: pip install --upgrade pip
+      - name: Install Poetry
+        run: pip install poetry
+      - name: Install Python dependencies
+        run: poetry install
       - name: Run mutation tests
         run: poetry run mutmut run
       - name: Create mutation test report


### PR DESCRIPTION
`python -m …` is only necessary if more than one Python version is installed, and we need to specify the Python executable explicitly.