### PR TITLE
fix: Don't attempt to install project inside virtualenv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Poetry
         run: pip install poetry
       - name: Install Python dependencies
-        run: poetry install
+        run: poetry install --no-root
       - name: Lint Last Commit
         if: github.event_name == 'push'
         run: poetry run gitlint

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Poetry
         run: pip install poetry
       - name: Install Python dependencies
-        run: poetry install
+        run: poetry install --no-root
       - name: Run mutation tests
         run: poetry run mutmut run --no-progress --runner="pytest --assert=plain --exitfirst"
       - name: Create mutation test report

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Optional dependencies:
 
 - [Pyenv](https://github.com/pyenv/pyenv) to use the reference Python version in `pyproject.toml` with a simple `pyenv install`
 
-1. Install the project dependencies: `poetry install`
+1. Install the project dependencies: `poetry install --no-root`
 2. Activate the virtualenv: `poetry shell`
 
 Install Git hooks:


### PR DESCRIPTION
Avoids the following:

```
Installing the current project: […]
Warning: The current project could not be installed: No file/folder found for package […]
If you do not want to install the current project use --no-root.
If you want to use Poetry only for dependency management but not for packaging, you can disable package mode by setting package-mode = false in your pyproject.toml file.
In a future version of Poetry this warning will become an error!
```